### PR TITLE
实现全文搜索、对各文章toc的搜索、“空格‘展开目录树全部文章

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,24 +2,41 @@ title: tree
 
 author: 吴俊
 
-menus: 
+menus:
   关于: /about
 
 links:
   github: https://github.com/wujun234
-  
+
 favicon: /favicon.ico
 
-# valine 
+searchAll: false
+# true 启用全文搜索
+# 在搜索框输入'in: 关键字' 实现全文搜索
+# 开启此功能需要下面操作：
+# 1. 在 hexo 根目录 执行 npm install hexo-generator-search --save 安装插件
+# 2. 在 hexo 根目录的 _config.xml 中添加下面内容
+# search:
+#   path: search.xml
+#   field: post
+
+searchTOC: false
+# true 启用对各文章toc的搜索
+
+expandAll: false
+# true '空格'展开目录树所有文章
+
+
+# valine
 valine:
     # 评论
-    enableComment: true 
+    enableComment: true
     # 阅读量
     enableCounter: false
     # valine appID
-    appID: 
+    appID:
     # valine appKey
-    appKey: 
+    appKey:
     placeholder: 请输入评论
     avatar: retro
 

--- a/layout/_partial/sidebar.ejs
+++ b/layout/_partial/sidebar.ejs
@@ -1,9 +1,11 @@
 
 <div id="sidebar">
 	<button id="sidebar-toggle" class="toggle" ><i class="fa fa-arrow-right " aria-hidden="true"></i></button>
-	
 	<div id="site-toc">
 		<input id="search-input" class="search-input" type="text" placeholder="search...">
+		<% if (theme.searchAll) { %>
+    <div id="local-search-result" style="display: none;"></div>
+    <% } %>
 		<div id="tree">
 			<%
 				<!-- 将路径转换成 tree 目录结构 -->
@@ -44,18 +46,20 @@
 				<!-- 递归输出侧边栏目录 tree -->
 				const showTree = (input) => {
 
-					<!-- 按 tile ascii 排序 -->
-					input.sort(function(a, b){
-						var len = a.title.length <= b.title.length ? a.title.length : b.title.length;
-						for ( var i = 0; i < len; i++ ) {
-							res = a.title[i].charCodeAt() - b.title[i].charCodeAt();
-							if ( res ) { return res }
-						}
-						if(a.title.length <= b.title.length){
-							return true;
-						}else{
-							return false;
-						}
+					<!-- 按tile ascii排序 -->
+					input.sort(function(a, b) {
+					    var len = a.title.length <= b.title.length ? a.title.length: b.title.length;
+					    for (var i = 0; i < len; i++) {
+					        res = a.title[i].charCodeAt() - b.title[i].charCodeAt();
+					        if (res) {
+					            return res
+					        }
+					    }
+					    if (a.title.length <= b.title.length) {
+					        return true;
+					    } else {
+					        return false;
+					    }
 					});
 
 					<!-- 循环输出 html 结构 -->
@@ -65,11 +69,16 @@
 			%>
 							<ul>
 								<li class="file<%- (is_post() && node.post._id == page._id) ? ' active' : '' %>">
+									<i class="fa fa-angle-right"></i>
 									<a href="<%- url_for(node.post.path) %><%-  %>">
-										<%- node.title %>
+										<%- node.title %><% if (theme.expandAll) { %>  &nbsp;<% } %>
 									</a>
 								</li>
 								<div class="article-toc" style="display: none;"></div>
+								<!-- 循环输出 隐藏toc 结构，便于搜索toc -->
+								<% if (theme.searchTOC) { %>
+								<div style="display: none;"><%- toc(node.post.content) %></div>
+								<% } %>
 							</ul>
 			<%
 						}
@@ -83,7 +92,7 @@
 									</a>
 									<%- showTree(node.children) %>
 								</li>
-								
+
 							</ul>
 			<%
 						}

--- a/source/css/main.css
+++ b/source/css/main.css
@@ -113,6 +113,23 @@ a {
 	text-indent: 20px;
 	color: #64cfff;
 }
+#local-search-result .search-result-list .search-result {
+  padding: 0 16px 0 32px;
+  margin: 0;
+  color: #808080;
+}
+.search-result-list .search-result .search-keyword,
+#local-search-result .search-result-list .search-result .search-keyword {
+  color: #f00;
+  font-style: normal;
+	font-weight:bold;
+}
+#local-search-result a {
+  display: block;
+  color: #42b983 !important;
+  position: relative;
+	padding-top: 10px;
+}
 .sidebar-toc {
 	position: absolute;
 	top: 0;
@@ -140,6 +157,7 @@ a {
 	height: calc( 100% - 5px );
 	padding-top: 5px;
 }
+#local-search-result,
 #tree{
 	height: calc( 100% - 50px );
 	overflow: auto;
@@ -340,7 +358,7 @@ table {
   background: transparent;
   border-collapse: collapse;
   border-spacing: 0;
-  text-align: left; 
+  text-align: left;
   border: 1px solid black;
 }
 table th {
@@ -349,7 +367,7 @@ table th {
 	border: 1px solid black;
 }
 table td {
-	padding: 5px 10px; 
+	padding: 5px 10px;
 	border: 1px solid black;
 }
 

--- a/source/js/main.js
+++ b/source/js/main.js
@@ -60,10 +60,13 @@ function switchTreeOrIndex(){
 //生成文章目录
 function showArticleIndex() {
 	$(".article-toc").empty();
-	$(".article-toc").hide();	
+	$(".article-toc").hide();
 	$(".article-toc.active-toc").removeClass("active-toc");
 	$("#tree .active").next().addClass('active-toc');
-	
+
+	$(".fa-angle-down").removeClass("fa-angle-down").addClass("fa-angle-right");
+	$(".file.active i").removeClass("fa-angle-right").addClass('fa-angle-down');
+
 	var labelList = $("#article-content").children();
 	var content = "<ul>";
 	var max_level = 4;
@@ -101,9 +104,9 @@ function showArticleIndex() {
 	content += "</ul>"
 
 	$(".article-toc.active-toc").append(content);
-	
+
 	if(null != $(".article-toc a") && 0 != $(".article-toc a").length){
-		
+
 		// 点击目录索引链接，动画跳转过去，不是默认闪现过去
 		$(".article-toc a").on("click", function(e){
 			e.preventDefault();
@@ -130,7 +133,7 @@ function showArticleIndex() {
 					tocLink.removeClass("read");
 				}
 			});
-		});	
+		});
 	}
 	$(".article-toc.active-toc").show();
 	$(".article-toc.active-toc").children().show();
@@ -161,7 +164,7 @@ function pjaxLoad(){
 						}
 					}
 					searchResult[0].parentNode.classList.add("active");
-					showActiveTree($("#tree .active"), true) 
+					showActiveTree($("#tree .active"), true)
 				}
 				showArticleIndex();
 			}
@@ -195,11 +198,26 @@ function serachTree() {
 		}
 		// 有值就搜索，并且展开父目录
 		else {
-			$(".fa-plus-square-o").removeClass("fa-plus-square-o").addClass("fa-minus-square-o");
-			$("#tree ul").css("display", "none");
-			var searchResult = $("#tree li").find("a:contains('" + inputContent + "')");
-			if ( searchResult.length ) { 
-				showActiveTree(searchResult.parent(), false) 
+				if ($('#local-search-result').length>0 && inputContent.length === 3 && (inputContent.substr(0,3).toLowerCase() === 'in:' || inputContent.substr(0,3).toLowerCase()==='in：')) {
+						// 全文搜索
+						$.getScript('/js/search.js', function () {
+								searchFunc("/search.xml", 'search-input', 'local-search-result');
+						})
+				}
+			  if ($('#local-search-result').length>0 && inputContent.length>3 && (inputContent.substr(0,3).toLowerCase() === 'in:' || inputContent.substr(0,3).toLowerCase()==='in：')) {
+					$('#local-search-result').show();
+					$("#tree ul").css("display", "none");
+
+					searchAll(inputContent.substr(3))
+			} else {
+					$('#local-search-result').hide();
+
+					$(".fa-plus-square-o").removeClass("fa-plus-square-o").addClass("fa-minus-square-o");
+					$("#tree ul").css("display", "none");
+					var searchResult = $("#tree li").find("a:contains('" + inputContent + "')");
+					if ( searchResult.length ) {
+						showActiveTree(searchResult.parent(), false)
+					}
 			}
 		}
 	});
@@ -247,7 +265,7 @@ function showActiveTree(jqNode, isSiblings) {
 		// 这个 isSiblings 是给搜索用的
 		// true 就显示开同级兄弟节点
 		// false 就是给搜索用的，值需要展示它自己就好了，不展示兄弟节点
-		if ( isSiblings ) { 
+		if ( isSiblings ) {
 			jqNode.siblings().css("display", "block");
 			jqNode.siblings("a").css("display", "inline");
 			jqNode.siblings("a").find(".fa-plus-square-o").removeClass("fa-plus-square-o").addClass("fa-minus-square-o");

--- a/source/js/search.js
+++ b/source/js/search.js
@@ -1,0 +1,147 @@
+// A local search script with the help of [hexo-generator-search](https://github.com/PaicHyperionDev/hexo-generator-search)
+// Copyright (C) 2015
+// Joseph Pan <http://github.com/wzpan>
+// Shuhao Mao <http://github.com/maoshuhao>
+// This library is free software; you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as
+// published by the Free Software Foundation; either version 2.1 of the
+// License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+// 02110-1301 USA
+//
+var searchAll;
+var searchFunc = function (path, search_id, content_id) {
+  'use strict';
+  $.ajax({
+    url: path,
+    dataType: 'xml',
+    complete: function (xmlResponse) {
+      // get the contents from search data
+        /* 由于 xml 不支持特殊字符，所有手动转 */
+        function createXml(str){
+            if(document.all){
+                var xmlDom=new ActiveXObject("Microsoft.XMLDOM");
+                xmlDom.loadXML(str);
+                return xmlDom;
+            }
+            else
+                return new DOMParser().parseFromString(str, "text/xml");
+        }
+      var datas = $("entry", createXml(xmlResponse.responseText)).map(function () {
+        return {
+          title: $("title", this).text(),
+          content: $("content", this).text(),
+          url: $("url", this).text()
+        };
+      }).get();
+
+      var $input = document.getElementById(search_id);
+      var $resultContent = document.getElementById(content_id);
+
+      searchAll = function (val) {
+        var str = '<ul class=\"search-result-list\">';
+        var keywords = val.trim().toLowerCase().trim().split(/[\s\-]+/);
+        $resultContent.innerHTML = "";
+        if (val.trim().length <= 0) {
+          return;
+        }
+        // perform local searching
+        datas.forEach(function (data) {
+          var isMatch = true;
+          var content_index = [];
+          if (!data.title || data.title.trim() === '') {
+            data.title = "Untitled";
+          }
+          var data_title = data.title.trim().toLowerCase();
+          var data_content = data.content.trim().replace(/<[^>]+>/g, "").toLowerCase();
+          var data_url = data.url;
+          var index_title = -1;
+          var index_content = -1;
+          var first_occur = -1;
+          // only match artiles with not empty contents
+          if (data_content !== '') {
+            keywords.forEach(function (keyword, i) {
+              index_title = data_title.indexOf(keyword);
+              index_content = data_content.indexOf(keyword);
+
+              if (index_title < 0 && index_content < 0) {
+                isMatch = false;
+              } else {
+                if (index_content < 0) {
+                  index_content = 0;
+                }
+                if (i == 0) {
+                  first_occur = index_content;
+                }
+                // content_index.push({index_content:index_content, keyword_len:keyword_len});
+              }
+            });
+          } else {
+            isMatch = false;
+          }
+          // show search results
+          if (isMatch) {
+            var urls = data_url.split("/");
+            var post_date = urls[1]+"/"+urls[2]+"/"+urls[3];
+            str += "<li><a href='" + data_url + "'><h3>▌ " + data_title + "</h3></a>";
+            var content = data.content.trim().replace(/<[^>]+>/g, "");
+            if (first_occur >= 0) {
+              // cut out 100 characters
+              var start = first_occur - 20;
+              var end = first_occur + 80;
+
+              if (start < 0) {
+                start = 0;
+              }
+
+              if (start == 0) {
+                end = 100;
+              }
+
+              if (end > content.length) {
+                end = content.length;
+              }
+
+              var match_content = content.substr(start, end);
+
+              // highlight all keywords
+              keywords.forEach(function (keyword) {
+                var regS = new RegExp(keyword, "gi");
+                match_content = match_content.replace(regS, "<em class=\"search-keyword\">" + keyword + "</em>");
+              });
+
+              str += "<p class=\"search-result\">" + match_content + "...</p>"
+            }
+            str += "</li>";
+          }
+        });
+        str += "</ul>";
+        if (str.indexOf('<li>') === -1) {
+          return $resultContent.innerHTML = "<ul><span class='local-search-empty'>没有找到内容，更换下搜索词试试吧~<span></ul>";
+        }
+        $resultContent.innerHTML = str;
+
+          $(document).pjax('#local-search-result a', '.pjax', {fragment: '.pjax', timeout: 8000});
+          /*鼠标移出文章列表后，去掉文章标题hover样式*/
+          $("#local-search-result a").mouseenter(function (e) {
+              $("#local-search-result a.hover").removeClass("hover");
+              $(this).addClass("hover");
+          });
+          $("#local-search-result a").mouseleave(function (e) {
+              $(this).removeClass("hover");
+          });
+      }
+    },
+      error: function (XMLHttpRequest, textStatus, errorThrown) {
+          console.log('文章中出现特殊字符，导致解析xml出现问题.')
+      }
+  });
+}


### PR DESCRIPTION
`_config.yml`上设置是否启用

```
searchAll: false
# true 启用全文搜索
# 在搜索框输入'in: 关键字' 实现全文搜索
# 开启此功能需要下面操作：
# 1. 在 hexo 根目录 执行 npm install hexo-generator-search --save 安装插件
# 2. 在 hexo 根目录的 _config.xml 中添加下面内容
# search:
#   path: search.xml
#   field: post

searchTOC: false
# true 启用对各文章toc的搜索

expandAll: false
# true '空格'展开目录树所有文章
```

说明：search.xml作为全文搜索文件，只有当输入`in:`的时候才会加载，这样不会影响网站加载速度