### PR TITLE
fix：文本内容异常挤压

### DIFF
--- a/source/css/main.css
+++ b/source/css/main.css
@@ -358,6 +358,10 @@ table td {
 	border: 1px solid black;
 }
 
+figure{
+    overflow:auto
+}
+
 .post-guide{
 	display: -webkit-box;
 	display: -moz-box;


### PR DESCRIPTION
修复了在小于484px时候，因为代码块宽度锁定引起的文章内容异常挤压问题

![image](https://github.com/wujun234/hexo-theme-tree/assets/108462724/ae76c1ef-13c4-4cc5-ae2d-6726069eb4ba)


